### PR TITLE
Look for `perltidy` in multiple directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Perltidy
 
-Perltidy for Atom.
+Run perltidy with `alt-p`.
 
-Started with `alt-p`, you may need to configure the location of your
-`perltidy` binary, which defaults to `/usr/local/bin/perltidy`.
+## Settings
+
+If your `perltidy` is installed in a non-standard location, you may have
+to adjust the directories.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perltidy",
   "main": "./index.js",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Perltidy for Atom.",
   "repository": "https://github.com/kraih/atom-perltidy",
   "engines": {


### PR DESCRIPTION
By default, look for the script in the standard directory ("/usr/local/bin")
and PATH directories matching "perl5" (useful when `perltidy` was installed
with `local::lib`).

![Screen Shot 2019-07-23 at 1 41 31 PM](https://user-images.githubusercontent.com/131140/61709531-c45d9600-ad4f-11e9-92f2-eb91123bd9ec.png)

NOTE: the default suggestions come from your PATH environment variable.